### PR TITLE
Regencies start (unfinished)

### DIFF
--- a/common/council_positions/00_council_positions.txt
+++ b/common/council_positions/00_council_positions.txt
@@ -336,6 +336,44 @@ councillor_spouse = {
 	name = {
 		first_valid = {
 			triggered_desc = {
+				trigger = {
+					scope:councillor_liege = {
+						has_government = feudal_government
+						OR = {
+							age < 16
+							#add incapable here
+							AND = {
+								is_male = no
+								OR = {
+									has_realm_law = male_only_law #shouldn't happen
+									has_realm_law = male_preference_law
+								}
+							}
+						}
+					}
+				}
+				desc = councillor_regent
+			}
+			triggered_desc = {
+				trigger = {
+					scope:councillor_liege = {
+						has_government = feudal_government
+						OR = {
+							age < 16
+							#add incapable here
+							AND = {
+								is_male = yes
+								OR = {
+									has_realm_law = female_only_law #shouldn't happen
+									has_realm_law = female_preference_law
+								}
+							}
+						}
+					}
+				}
+				desc = councillor_regent
+			}
+			triggered_desc = {
 				trigger = { is_male = yes }
 				desc = {
 					first_valid = {
@@ -2260,24 +2298,78 @@ councillor_spouse = {
 		}
 	}
 
-	tooltip = game_concept_spouse_desc
+	tooltip = game_concept_spouse_desc #needs to be changes
+
+	#modifier = {                               #use these if desired for regents
+		#name = learn_on_the_job_modifier
+		#learning = 1
+		#scale = court_chaplain_regent_learn
+	#}
+
+	#modifier = {
+		#name = learn_on_the_job_modifier
+		#diplomacy = 1
+		#scale = chancellor_regent_learn
+	#}
+
+	#modifier = {
+		#name = learn_on_the_job_modifier
+		#stewardship = 1
+		#scale = steward_regent_learn
+	#}
+
+	#modifier = {
+		#name = learn_on_the_job_modifier
+		#martial = 1
+		#scale = marshal_regent_learn
+	#}
+
+	#modifier = {
+		#name = learn_on_the_job_modifier
+		#intrigue = 1
+		#scale = spymaster_regent_learn
+	#}
 
 	valid_position = {
-		any_spouse = {
-			OR = {
-				court_owner = root
-				AND = {
-					is_ruler = yes
-					exists = liege
-					liege = root
+		OR = {
+			any_spouse = {
+				OR = {
+					court_owner = root
+					AND = {
+						is_ruler = yes
+						exists = liege
+						liege = root
+					}
+				}
+			}
+			AND = {
+				has_government = feudal_government
+				OR = {
+					is_capable_adult = no
+					is_imprisoned = yes
+					age < 16
+					AND = {
+						is_male = no
+						OR = {
+							has_realm_law = male_only_law #shouldn't happen
+							has_realm_law = male_preference_law
+						}
+					}
+					AND = {
+						is_male = yes
+						OR = {
+							has_realm_law = female_only_law #shouldn't happen
+							has_realm_law = female_preference_law
+						}
+					}
 				}
 			}
 		}
 	}
 
 	valid_character = {
-		exists = liege
-		can_be_spouse_councillor_trigger = { COUNCIL_OWNER = liege }
+		exists = root.liege_or_court_owner
+		can_be_spouse_or_regent_trigger = { COUNCIL_OWNER = root.liege_or_court_owner }
 	}
 
 	on_get_position = {

--- a/common/on_action/regency_on_actions.txt
+++ b/common/on_action/regency_on_actions.txt
@@ -1,0 +1,28 @@
+﻿on_title_gain_inheritance = {
+	on_actions = {
+		on_regency_assign
+	}
+}
+on_regency_assign = {
+	trigger = {
+		NOT = {
+			has_character_flag = regent_assigned
+		}
+	}
+	events = {
+		regency.001
+	}
+}
+on_death = {
+	on_actions = {
+		on_regent_death
+	}
+}
+on_regent_death = {
+	trigger = {
+		has_character_flag = is_assigned_regent
+	}
+	events = {
+		regency.002
+	}
+}

--- a/common/script_values/regency_values.txt
+++ b/common/script_values/regency_values.txt
@@ -1,0 +1,330 @@
+﻿court_chaplain_regent_learn = {
+    value = 0
+    if = {
+        limit = {
+			has_perk = learn_on_the_job_perk
+            OR = {
+				liege = {
+					has_government = feudal_government
+					OR = {
+						is_capable_adult = no
+						is_imprisoned = yes
+						age < 16
+						AND = {
+							is_male = no
+							OR = {
+								has_realm_law = male_only_law #shouldn't happen
+								has_realm_law = male_preference_law
+							}
+						}
+						AND = {
+							is_male = yes
+							OR = {
+								has_realm_law = female_only_law #shouldn't happen
+								has_realm_law = female_preference_law
+							}
+						}
+					}
+				}
+				primary_spouse = {
+					has_government = feudal_government
+					OR = {
+						is_capable_adult = no
+						is_imprisoned = yes
+						age < 16
+						AND = {
+							is_male = no
+							OR = {
+								has_realm_law = male_only_law #shouldn't happen
+								has_realm_law = male_preference_law
+							}
+						}
+						AND = {
+							is_male = yes
+							OR = {
+								has_realm_law = female_only_law #shouldn't happen
+								has_realm_law = female_preference_law
+							}
+						}
+					}
+				}
+			}
+        }
+		liege = {
+			every_learning_councillor = {
+				limit = {has_council_position = councillor_court_chaplain}
+				add = learning
+				multiply = {
+					add = learn_on_the_job_percentage
+					divide = 100
+				}
+				floor = yes
+				min = 1
+			}
+		}
+    }
+}
+spymaster_regent_learn = {
+    value = 0
+    if = {
+        limit = {
+			has_perk = learn_on_the_job_perk
+            OR = {
+				liege = {
+					has_government = feudal_government
+					OR = {
+						is_capable_adult = no
+						is_imprisoned = yes
+						age < 16
+						AND = {
+							is_male = no
+							OR = {
+								has_realm_law = male_only_law #shouldn't happen
+								has_realm_law = male_preference_law
+							}
+						}
+						AND = {
+							is_male = yes
+							OR = {
+								has_realm_law = female_only_law #shouldn't happen
+								has_realm_law = female_preference_law
+							}
+						}
+					}
+				}
+				primary_spouse = {
+					has_government = feudal_government
+					OR = {
+						is_capable_adult = no
+						is_imprisoned = yes
+						age < 16
+						AND = {
+							is_male = no
+							OR = {
+								has_realm_law = male_only_law #shouldn't happen
+								has_realm_law = male_preference_law
+							}
+						}
+						AND = {
+							is_male = yes
+							OR = {
+								has_realm_law = female_only_law #shouldn't happen
+								has_realm_law = female_preference_law
+							}
+						}
+					}
+				}
+			}
+        }
+		liege = {
+			every_intrigue_councillor = {
+				limit = {has_council_position = councillor_spymaster}
+				add = intrigue
+				multiply = {
+					add = learn_on_the_job_percentage
+					divide = 100
+				}
+				floor = yes
+				min = 1
+			}
+		}
+    }
+}
+marshal_regent_learn = {
+    value = 0
+    if = {
+        limit = {
+			has_perk = learn_on_the_job_perk
+            OR = {
+				liege = {
+					has_government = feudal_government
+					OR = {
+						is_capable_adult = no
+						is_imprisoned = yes
+						age < 16
+						AND = {
+							is_male = no
+							OR = {
+								has_realm_law = male_only_law #shouldn't happen
+								has_realm_law = male_preference_law
+							}
+						}
+						AND = {
+							is_male = yes
+							OR = {
+								has_realm_law = female_only_law #shouldn't happen
+								has_realm_law = female_preference_law
+							}
+						}
+					}
+				}
+				primary_spouse = {
+					has_government = feudal_government
+					OR = {
+						is_capable_adult = no
+						is_imprisoned = yes
+						age < 16
+						AND = {
+							is_male = no
+							OR = {
+								has_realm_law = male_only_law #shouldn't happen
+								has_realm_law = male_preference_law
+							}
+						}
+						AND = {
+							is_male = yes
+							OR = {
+								has_realm_law = female_only_law #shouldn't happen
+								has_realm_law = female_preference_law
+							}
+						}
+					}
+				}
+			}
+        }
+		liege = {
+			every_martial_councillor = {
+				limit = {has_council_position = councillor_marshal}
+				add = martial
+				multiply = {
+					add = learn_on_the_job_percentage
+					divide = 100
+				}
+				floor = yes
+				min = 1
+			}
+		}
+    }
+}
+steward_regent_learn = {
+    value = 0
+    if = {
+        limit = {
+			has_perk = learn_on_the_job_perk
+            OR = {
+				liege = {
+					has_government = feudal_government
+					OR = {
+						is_capable_adult = no
+						is_imprisoned = yes
+						age < 16
+						AND = {
+							is_male = no
+							OR = {
+								has_realm_law = male_only_law #shouldn't happen
+								has_realm_law = male_preference_law
+							}
+						}
+						AND = {
+							is_male = yes
+							OR = {
+								has_realm_law = female_only_law #shouldn't happen
+								has_realm_law = female_preference_law
+							}
+						}
+					}
+				}
+				primary_spouse = {
+					has_government = feudal_government
+					OR = {
+						is_capable_adult = no
+						is_imprisoned = yes
+						age < 16
+						AND = {
+							is_male = no
+							OR = {
+								has_realm_law = male_only_law #shouldn't happen
+								has_realm_law = male_preference_law
+							}
+						}
+						AND = {
+							is_male = yes
+							OR = {
+								has_realm_law = female_only_law #shouldn't happen
+								has_realm_law = female_preference_law
+							}
+						}
+					}
+				}
+			}
+        }
+		liege = {
+			every_stewardship_councillor = {
+				limit = {has_council_position = councillor_steward}
+				add = stewardship
+				multiply = {
+					add = learn_on_the_job_percentage
+					divide = 100
+				}
+				floor = yes
+				min = 1
+			}
+		}
+    }
+}
+chancellor_regent_learn = {
+    value = 0
+    if = {
+        limit = {
+			has_perk = learn_on_the_job_perk
+            OR = {
+				liege = {
+					has_government = feudal_government
+					OR = {
+						is_capable_adult = no
+						is_imprisoned = yes
+						age < 16
+						AND = {
+							is_male = no
+							OR = {
+								has_realm_law = male_only_law #shouldn't happen
+								has_realm_law = male_preference_law
+							}
+						}
+						AND = {
+							is_male = yes
+							OR = {
+								has_realm_law = female_only_law #shouldn't happen
+								has_realm_law = female_preference_law
+							}
+						}
+					}
+				}
+				primary_spouse = {
+					has_government = feudal_government
+					OR = {
+						is_capable_adult = no
+						is_imprisoned = yes
+						age < 16
+						AND = {
+							is_male = no
+							OR = {
+								has_realm_law = male_only_law #shouldn't happen
+								has_realm_law = male_preference_law
+							}
+						}
+						AND = {
+							is_male = yes
+							OR = {
+								has_realm_law = female_only_law #shouldn't happen
+								has_realm_law = female_preference_law
+							}
+						}
+					}
+				}
+			}
+        }
+		liege = {
+			every_diplomacy_councillor = {
+				limit = {has_council_position = councillor_chancellor}
+				add = diplomacy
+				multiply = {
+					add = learn_on_the_job_percentage
+					divide = 100
+				}
+				floor = yes
+				min = 1
+			}
+		}
+    }
+}

--- a/common/scripted_triggers/regency_triggers.txt
+++ b/common/scripted_triggers/regency_triggers.txt
@@ -1,0 +1,28 @@
+﻿can_be_spouse_or_regent_trigger = {
+	save_temporary_scope_as = regent_councilor_check
+	can_be_councillor_basics_trigger = yes
+	trigger_if = {
+		limit = { $COUNCIL_OWNER$  = { exists = primary_spouse } }
+		trigger_if = {
+			limit = { is_ruler = yes }
+			exists = liege
+			liege = $COUNCIL_OWNER$
+			$COUNCIL_OWNER$ = { primary_spouse = scope:regent_councilor_check }
+		}
+		trigger_else = {
+			exists = $COUNCIL_OWNER$
+			$COUNCIL_OWNER$ = { primary_spouse = scope:regent_councilor_check }
+		}
+	}
+	trigger_else_if = {
+		limit = { $COUNCIL_OWNER$ = {has_character_flag = regent_assigned} }
+		exists = $COUNCIL_OWNER$
+		has_character_flag = is_assigned_regent
+		var:regent_assigned_to = {
+			this = $COUNCIL_OWNER$
+		}
+	}
+	trigger_else = {
+		always = no
+	}
+}

--- a/events/regency_events.txt
+++ b/events/regency_events.txt
@@ -1,0 +1,82 @@
+﻿namespace = regency
+
+regency.001 = {
+	type = character_event
+	hidden = yes
+	trigger = {
+		has_government = feudal_government
+	}
+	immediate = {
+		save_scope_as = invalid_ruler
+		hidden_effect = {
+			every_parent = {
+				limit = {is_alive = yes}
+				add_to_list = regent_candidates
+			}
+			every_vassal = {
+				limit = { 
+					age > 16 
+					has_government = feudal_government
+				}
+				add_to_list = regent_candidates
+			}
+			every_courtier = {
+				limit = { age > 16 }
+				add_to_list = regent_candidates
+			}
+			every_heir = {
+				limit = { age > 16 }
+				if = {
+					limit = {
+						is_ruler = yes
+						exists = liege
+						liege = scope:invalid_ruler
+					}
+					add_to_list = regent_candidates
+				}
+				else_if = {
+					limit = {is_ruler = no}
+					add_to_list = regent_candidates
+				}
+			}
+			random_in_list = {
+				list = regent_candidates
+				limit = { has_relation_guardian = scope:invalid_ruler }
+				alternative_limit = {is_parent_of = scope:invalid_ruler}
+				alternative_limit = {is_heir_of = scope:invalid_ruler}
+				alternative_limit = {is_powerful_vassal_of = scope:invalid_ruler}
+				alternative_limit = {is_vassal_of = scope:invalid_ruler}
+				alternative_limit = {is_courtier_of = scope:invalid_ruler}
+				add_character_flag = is_assigned_regent
+				clear_variable_list = regent_assigned_to
+				set_variable = { name = regent_assigned_to value = scope:invalid_ruler }
+				if = {
+					limit = {scope:invalid_ruler = { age < 16 } }
+					set_relation_ward = scope:invalid_ruler
+				}
+				if = {
+					limit = {
+						is_ruler = no
+						NOT = {
+							employer = scope:invalid_ruler
+						}
+					}
+					set_employer = scope:invalid_ruler
+				}
+			}
+			add_character_flag = regent_assigned
+		}
+	}
+}
+regency.002 = {
+	hidden = yes
+	immediate = {
+		var:regent_assigned_to = {
+			remove_character_flag = regent_assigned
+			trigger_event = {
+				id = regency.001
+				days = 1
+			}
+		}
+	}
+}


### PR DESCRIPTION
events look for accessible regents.

Council position finds if the character should have a regent.

Spouse becomes regent preferably.

can be set to boost regent's stats (unfinished remove councilor bonus from the player/holder as they aren't in charage anymore.

Needs events